### PR TITLE
fix: html-plugin cheerio breakage + lint/test baseline

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,10 @@
   "main": "scripts/index.js",
   "scripts": {
     "build": "NODE_OPTIONS=--openssl-legacy-provider NODE_ENV=production webpack -p",
+    "build:dev": "NODE_OPTIONS=--openssl-legacy-provider webpack",
     "start": "NODE_OPTIONS=--openssl-legacy-provider webpack-dev-server -d --watch",
-    "test": "eslint . && NODE_OPTIONS=--openssl-legacy-provider webpack"
+    "lint": "eslint .",
+    "test": "node --test \"tests/*.test.js\""
   },
   "keywords": [
     "boilerplate",

--- a/plugins/html-plugin.js
+++ b/plugins/html-plugin.js
@@ -29,8 +29,8 @@ HtmlParserWebpackPlugin.prototype.compile = function(file, compilation, callback
   var input = path.join(this.compiler.context, file);
   var html = $.load(fs.readFileSync(input));
   html("[href],[src]").each(function(i, element) {
-    this.parse(element, "href", compilation);
-    this.parse(element, "src", compilation);
+    this.parse(html, element, "href", compilation);
+    this.parse(html, element, "src", compilation);
   }.bind(this));
 
   var htmlSource = html.html();
@@ -47,14 +47,14 @@ HtmlParserWebpackPlugin.prototype.compile = function(file, compilation, callback
 };
 
 /* If the elementh with the tag includes a '!' prefix, it should be emitted */
-HtmlParserWebpackPlugin.prototype.parse = function(element, attr, compilation) {
-  var file = $(element).attr(attr);
+HtmlParserWebpackPlugin.prototype.parse = function(html, element, attr, compilation) {
+  var file = html(element).attr(attr);
   // If the element does not have a valid href or src, or if it does not
   // require bundling, don't do anything.
   if (!file || file[0] !== "!") {
     return;
   }
-  $(element).attr(attr, this.emit(file.substring(1), compilation));
+  html(element).attr(attr, this.emit(file.substring(1), compilation));
 };
 
 /* Create a file on the dist directory for the resource with a md5 name */

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -1,0 +1,12 @@
+var test = require("node:test");
+var assert = require("node:assert/strict");
+
+var defaultConfig = require("../config/default.json");
+var productionConfig = require("../config/production.json");
+
+test("environment configs parse and define the DEBUG flag correctly", function() {
+  assert.equal(typeof defaultConfig.DEBUG, "boolean");
+  assert.equal(typeof productionConfig.DEBUG, "boolean");
+  assert.equal(defaultConfig.DEBUG, true, "development should run in debug mode");
+  assert.equal(productionConfig.DEBUG, false, "production must not run in debug mode");
+});

--- a/tests/html-plugin.test.js
+++ b/tests/html-plugin.test.js
@@ -1,0 +1,73 @@
+var test = require("node:test");
+var assert = require("node:assert/strict");
+var fs = require("fs");
+var path = require("path");
+var md5 = require("md5");
+
+var HtmlParserWebpackPlugin = require("../plugins/html-plugin");
+
+var ROOT = path.join(__dirname, "..");
+
+test("createFile registers an asset with correct source and size", function() {
+  var plugin = new HtmlParserWebpackPlugin("index.html");
+  var compilation = { assets: {} };
+
+  plugin.createFile(compilation, "foo.txt", "hello world");
+
+  assert.ok(compilation.assets["foo.txt"], "asset should be registered");
+  assert.equal(compilation.assets["foo.txt"].source(), "hello world");
+  assert.equal(compilation.assets["foo.txt"].size(), 11);
+});
+
+test("emit creates an md5-named asset from a real file", function() {
+  var plugin = new HtmlParserWebpackPlugin();
+  plugin.compiler = { context: ROOT };
+  var compilation = { assets: {} };
+
+  var filename = plugin.emit("config/default.json", compilation);
+  var source = fs.readFileSync(path.join(ROOT, "config/default.json"));
+
+  assert.equal(filename, md5(source) + ".json");
+  assert.ok(compilation.assets[filename], "emitted asset should be registered");
+  assert.equal(String(compilation.assets[filename].source()), String(source));
+});
+
+test("compile parses index.html and rewrites '!' assets to hashed names", function(t, done) {
+  var plugin = new HtmlParserWebpackPlugin("index.html");
+  plugin.compiler = { context: ROOT };
+  var compilation = { assets: {} };
+
+  plugin.compile("index.html", compilation, function() {
+    var asset = compilation.assets["index.html"];
+    assert.ok(asset, "processed index.html should be emitted");
+
+    var html = String(asset.source());
+    assert.ok(html.indexOf("!assets/") === -1,
+              "'!' prefixed references should be rewritten");
+
+    var favicon = fs.readFileSync(path.join(ROOT, "assets/images/favicon.png"));
+    var hashedName = md5(favicon) + ".png";
+    assert.ok(html.indexOf(hashedName) !== -1,
+              "html should reference the hashed favicon");
+    assert.ok(compilation.assets[hashedName],
+              "hashed favicon asset should be emitted");
+    done();
+  });
+});
+
+test("apply detects production mode from CLI flags", function() {
+  var fakeCompiler = { plugin: function() {}, options: {} };
+
+  var plugin = new HtmlParserWebpackPlugin("index.html");
+  plugin.apply(fakeCompiler);
+  assert.equal(plugin.production, false, "no -p flag means development mode");
+
+  process.argv.push("-p");
+  try {
+    var productionPlugin = new HtmlParserWebpackPlugin("index.html");
+    productionPlugin.apply(fakeCompiler);
+    assert.equal(productionPlugin.production, true, "-p flag enables production mode");
+  } finally {
+    process.argv.pop();
+  }
+});


### PR DESCRIPTION
## Summary
- Fix html-plugin: cheerio 1.2.0's top-level export is not callable, so `parse()` threw inside webpack's emit hook (unhandled rejection) and `index.html` was silently never emitted; now passes the load-bound cheerio instance into `parse()`
- Add `lint` script for the existing eslint 6 setup
- `test` script now runs real node:test smoke tests (html-plugin behavior incl. regression test for the cheerio fix, config JSONs); dev build preserved as `build:dev`
- Zero new dependencies

## Verification
- `npm run build:dev` emits processed `index.html` with hashed asset refs
- `npm run lint` passes
- `npm test` passes (5/5 tests)

cc @nihey

🤖 Generated with [Claude Code](https://claude.com/claude-code)